### PR TITLE
uncommented out line in json example that used to crash the Swift compiler

### DIFF
--- a/example-json/main.swift
+++ b/example-json/main.swift
@@ -130,14 +130,7 @@ func pair () -> StringParser<(String, Json)>.T {
 }
 
 func array () -> StringParser<Json>.T {
-  // the next line crashes the compiler with "Segmentation fault: 11"
-  // return between(leftBracket(), rightBracket(), sepBy(value(), comma()))
-  //     >>- { js in create(.array(js)) }
-  // as a result, we can't have an array within an array for now
-  func element () -> StringParser<Json>.T {
-    return null() <|> bool() <|> number() <|> str() <|> object()
-  }
-  return between(leftBracket(), rightBracket(), sepBy(element(), comma()))
+  return between(leftBracket(), rightBracket(), sepBy(value(), comma()))
       >>- { js in create(.array(js)) }
       <?> "array"
 }


### PR DESCRIPTION
This just works with Xcode 8 beta 6, so I just uncommented it.
