### PR TITLE
make Parser & StringParser proper generic typaliases

### DIFF
--- a/Parsec/Character.swift
+++ b/Parsec/Character.swift
@@ -7,11 +7,11 @@
     string `s`. Returns the parsed character. See also
     'satisfy'.
 
-        func vowel () -> StringParser<Character>.T {
+        func vowel () -> StringParser<Character> {
           return oneOf("aeiou")
         }
 */
-public func oneOf<c: Collection> (_ s: String) -> Parser<Character, c>.T
+public func oneOf<c: Collection> (_ s: String) -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return satisfy { c in s.contains(String(c)) }
@@ -22,11 +22,11 @@ public func oneOf<c: Collection> (_ s: String) -> Parser<Character, c>.T
     character is *not* in the supplied string `s`. Returns the
     parsed character.
 
-        func consonant () -> StringParser<Character>.T {
+        func consonant () -> StringParser<Character> {
           return noneOf("aeiou")
         }
 */
-public func noneOf<c: Collection> (_ s: String) -> Parser<Character, c>.T
+public func noneOf<c: Collection> (_ s: String) -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return satisfy { c in !s.contains(String(c)) }
@@ -35,7 +35,7 @@ public func noneOf<c: Collection> (_ s: String) -> Parser<Character, c>.T
 /**
     Skips *zero* or more white space characters. See also 'skipMany'.
 */
-public func spaces<c: Collection> () -> Parser<(), c>.T
+public func spaces<c: Collection> () -> Parser<(), c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return skipMany(space()) <?> "white space"
@@ -45,7 +45,7 @@ public func spaces<c: Collection> () -> Parser<(), c>.T
     Parses a white space character (any character which satisfies 'isSpace').
     Returns the parsed character.
 */
-public func space<c: Collection> () -> Parser<Character, c>.T
+public func space<c: Collection> () -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return satisfy(isSpace) <?> "space"
@@ -54,7 +54,7 @@ public func space<c: Collection> () -> Parser<Character, c>.T
 /**
     Parses a newline character ('\n'). Returns a newline character.
 */
-public func newline<c: Collection> () -> Parser<Character, c>.T
+public func newline<c: Collection> () -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return char("\n") <?> "lf new-line"
@@ -64,7 +64,7 @@ public func newline<c: Collection> () -> Parser<Character, c>.T
     Parses a carriage return character ('\r') followed by a newline character ('\n').
     Returns a newline character.
 */
-public func crlf<c: Collection> () -> Parser<Character, c>.T
+public func crlf<c: Collection> () -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return char("\r") >>> char("\n") <?> "crlf new-line"
@@ -74,7 +74,7 @@ public func crlf<c: Collection> () -> Parser<Character, c>.T
     Parses a CRLF (see 'crlf') or LF (see 'newline') end-of-line.
     Returns a newline character ('\n').
 */
-public func endOfLine<c: Collection> () -> Parser<Character, c>.T
+public func endOfLine<c: Collection> () -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return newline() <|> crlf() <?> "new-line"
@@ -83,7 +83,7 @@ public func endOfLine<c: Collection> () -> Parser<Character, c>.T
 /**
     Parses a tab character ('\t'). Returns a tab character.
 */
-public func tab<c: Collection> () -> Parser<Character, c>.T
+public func tab<c: Collection> () -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return char("\t") <?> "tab"
@@ -93,7 +93,7 @@ public func tab<c: Collection> () -> Parser<Character, c>.T
     Parses an upper case letter (a character between 'A' and 'Z').
     Returns the parsed character.
 */
-public func upper<c: Collection> () -> Parser<Character, c>.T
+public func upper<c: Collection> () -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return satisfy(isUpper) <?> "uppercase letter"
@@ -103,7 +103,7 @@ public func upper<c: Collection> () -> Parser<Character, c>.T
     Parses a lower case character (a character between 'a' and 'z').
     Returns the parsed character.
 */
-public func lower<c: Collection> () -> Parser<Character, c>.T
+public func lower<c: Collection> () -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return satisfy(isLower) <?> "lowercase letter"
@@ -113,7 +113,7 @@ public func lower<c: Collection> () -> Parser<Character, c>.T
     Parses a letter or digit (a character between '0' and '9').
     Returns the parsed character.
 */
-public func alphaNum<c: Collection> () -> Parser<Character, c>.T
+public func alphaNum<c: Collection> () -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return satisfy(isAlphaNum) <?> "letter or digit"
@@ -123,7 +123,7 @@ public func alphaNum<c: Collection> () -> Parser<Character, c>.T
     Parses a letter (an upper case or lower case character). Returns the
     parsed character.
 */
-public func letter<c: Collection> () -> Parser<Character, c>.T
+public func letter<c: Collection> () -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return satisfy(isLetter) <?> "letter"
@@ -132,7 +132,7 @@ public func letter<c: Collection> () -> Parser<Character, c>.T
 /**
     Parses a digit. Returns the parsed character.
 */
-public func digit<c: Collection> () -> Parser<Character, c>.T
+public func digit<c: Collection> () -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return satisfy(isDigit) <?> "digit"
@@ -142,7 +142,7 @@ public func digit<c: Collection> () -> Parser<Character, c>.T
     Parses a hexadecimal digit (a digit or a letter between 'a' and
     'f' or 'A' and 'F'). Returns the parsed character.
 */
-public func hexDigit<c: Collection> () -> Parser<Character, c>.T
+public func hexDigit<c: Collection> () -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return satisfy(isHexDigit) <?> "hexadecimal digit"
@@ -152,7 +152,7 @@ public func hexDigit<c: Collection> () -> Parser<Character, c>.T
     Parses an octal digit (a character between '0' and '7'). Returns
     the parsed character.
 */
-public func octDigit<c: Collection> () -> Parser<Character, c>.T
+public func octDigit<c: Collection> () -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return satisfy(isOctDigit) <?> "octal digit"
@@ -162,11 +162,11 @@ public func octDigit<c: Collection> () -> Parser<Character, c>.T
     `char(c)` parses a single character `c`. Returns the parsed
     character (i.e. `c`).
 
-        func semiColon () -> StringParser<Character>.T {
+        func semiColon () -> StringParser<Character> {
           return char(";")
         }
 */
-public func char<c: Collection> (_ c: Character) -> Parser<Character, c>.T
+public func char<c: Collection> (_ c: Character) -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return satisfy { x in x == c } <?> String(c)
@@ -175,7 +175,7 @@ public func char<c: Collection> (_ c: Character) -> Parser<Character, c>.T
 /**
     This parser succeeds for any character. Returns the parsed character.
 */
-public func anyChar<c: Collection> () -> Parser<Character, c>.T
+public func anyChar<c: Collection> () -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   return satisfy { _ in true }
@@ -186,11 +186,11 @@ public func anyChar<c: Collection> () -> Parser<Character, c>.T
     supplied function `f` returns 'true'. Returns the character that is
     actually parsed.
 
-        func digit () -> StringParser<Character>.T {
+        func digit () -> StringParser<Character> {
           return satisfy(isDigit)
         }
 */
-public func satisfy<c: Collection> (_ f: @escaping (Character) -> Bool) -> Parser<Character, c>.T
+public func satisfy<c: Collection> (_ f: @escaping (Character) -> Bool) -> Parser<Character, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   func show (_ c: Character) -> String {
@@ -211,12 +211,12 @@ public func satisfy<c: Collection> (_ f: @escaping (Character) -> Bool) -> Parse
     `string(s)` parses a string given by `s`. Returns
     the parsed string (i.e. `s`).
 
-        func divOrMod () -> StringParser<String>.T {
+        func divOrMod () -> StringParser<String> {
           return string("div")
             <|> string("mod")
         }
 */
-public func string<c: Collection> (_ s: String) -> Parser<String, c>.T
+public func string<c: Collection> (_ s: String) -> Parser<String, c>
   where c.SubSequence == c, c.Iterator.Element == Character
 {
   func show (_ cs: [Character]) -> String {

--- a/Parsec/Combinator.swift
+++ b/Parsec/Combinator.swift
@@ -7,7 +7,7 @@
     until one of them succeeds. Returns the value of the succeeding
     parser.
 */
-public func choice<a, c: Collection> (_ ps: [Parser<a, c>.T]) -> Parser<a, c>.T {
+public func choice<a, c: Collection> (_ ps: [Parser<a, c>]) -> Parser<a, c> {
   return ps.reversed().reduce(parserZero(), parserPlus)
 }
 
@@ -16,7 +16,7 @@ public func choice<a, c: Collection> (_ ps: [Parser<a, c>.T]) -> Parser<a, c>.T 
     consuming input, it returns the value `x`, otherwise the value
     returned by `p`.
 
-        func priority () -> StringParser<Int>.T {
+        func priority () -> StringParser<Int> {
           return option(0, digit() >>- { d in
             if let i = Int(String(d)) {
               return create(i)
@@ -26,7 +26,7 @@ public func choice<a, c: Collection> (_ ps: [Parser<a, c>.T]) -> Parser<a, c>.T 
           })
         }
 */
-public func option<a, c: Collection> (_ x: a, _ p: Parser<a, c>.T) -> Parser<a, c>.T {
+public func option<a, c: Collection> (_ x: a, _ p: Parser<a, c>) -> Parser<a, c> {
   return p <|> create(x)
 }
 
@@ -35,7 +35,7 @@ public func option<a, c: Collection> (_ x: a, _ p: Parser<a, c>.T) -> Parser<a, 
     consuming input, it returns '.none', otherwise it returns
     '.some' the value returned by `p`.
 */
-public func optionMaybe<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<a?, c>.T {
+public func optionMaybe<a, c: Collection> (_ p: Parser<a, c>) -> Parser<a?, c> {
   return p >>- { x in create(x) } <|> create(nil)
 }
 
@@ -44,7 +44,7 @@ public func optionMaybe<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<a?, c>
     It only fails if `p` fails after consuming input. It discards the result
     of `p`.
 */
-public func optional<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<(), c>.T {
+public func optional<a, c: Collection> (_ p: Parser<a, c>) -> Parser<(), c> {
   return p >>> create(()) <|> create(())
 }
 
@@ -52,11 +52,11 @@ public func optional<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<(), c>.T 
     `between(open, close, p)` parses `open`, followed by `p` and `close`.
     Returns the value returned by `p`.
 
-        func braces<a> (_ p: StringParser<a>.T) -> StringParser<a>.T {
+        func braces<a> (_ p: StringParser<a>) -> StringParser<a> {
           return between(char("{"), char("}"), p)
         }
 */
-public func between<a, c: Collection, x, y> (_ open: Parser<x, c>.T, _ close: Parser<y, c>.T, _ p: Parser<a, c>.T) -> Parser<a, c>.T {
+public func between<a, c: Collection, x, y> (_ open: Parser<x, c>, _ close: Parser<y, c>, _ p: Parser<a, c>) -> Parser<a, c> {
   return open >>> p >>- { x in
     close >>> create(x)
   }
@@ -66,7 +66,7 @@ public func between<a, c: Collection, x, y> (_ open: Parser<x, c>.T, _ close: Pa
     `skipMany1(p)` applies the parser `p` *one* or more times, skipping
     its result.
 */
-public func skipMany1<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<(), c>.T {
+public func skipMany1<a, c: Collection> (_ p: Parser<a, c>) -> Parser<(), c> {
   return p >>> skipMany(p)
 }
 
@@ -74,11 +74,11 @@ public func skipMany1<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<(), c>.T
     `many1(p)` applies the parser `p` *one* or more times. Returns an
     array of the returned values of `p`.
 
-        func word () -> StringParser<[Character]>.T {
+        func word () -> StringParser<[Character]> {
           return many1(letter())
         }
 */
-public func many1<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<[a], c>.T {
+public func many1<a, c: Collection> (_ p: Parser<a, c>) -> Parser<[a], c> {
   return p >>- { x in
     many(p) >>- { xs in
       var r = [x]
@@ -92,11 +92,11 @@ public func many1<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<[a], c>.T {
     `sepBy(p, sep)` parses *zero* or more occurrences of `p`, separated
     by `sep`. Returns a list of values returned by `p`.
 
-        func commaSep<a> (_ p: StringParser<a>.T) -> StringParser<[a]>.T {
+        func commaSep<a> (_ p: StringParser<a>) -> StringParser<[a]> {
           return sepBy(p, char(","))
         }
 */
-public func sepBy<a, c: Collection, x> (_ p: Parser<a, c>.T, _ sep: Parser<x, c>.T) -> Parser<[a], c>.T {
+public func sepBy<a, c: Collection, x> (_ p: Parser<a, c>, _ sep: Parser<x, c>) -> Parser<[a], c> {
   return sepBy1(p, sep) <|> create([])
 }
 
@@ -104,7 +104,7 @@ public func sepBy<a, c: Collection, x> (_ p: Parser<a, c>.T, _ sep: Parser<x, c>
     `sepBy1(p, sep)` parses *one* or more occurrences of `p`, separated
     by `sep`. Returns a list of values returned by `p`.
 */
-public func sepBy1<a, c: Collection, x> (_ p: Parser<a, c>.T, _ sep: Parser<x, c>.T) -> Parser<[a], c>.T {
+public func sepBy1<a, c: Collection, x> (_ p: Parser<a, c>, _ sep: Parser<x, c>) -> Parser<[a], c> {
   return p >>- { x in
     many(sep >>> p) >>- { xs in
       var r = [x]
@@ -119,7 +119,7 @@ public func sepBy1<a, c: Collection, x> (_ p: Parser<a, c>.T, _ sep: Parser<x, c
     separated and optionally ended by `sep`. Returns a list of values
     returned by `p`.
 */
-public func sepEndBy1<a, c: Collection, x> (_ p: Parser<a, c>.T, _ sep: Parser<x, c>.T) -> Parser<[a], c>.T {
+public func sepEndBy1<a, c: Collection, x> (_ p: Parser<a, c>, _ sep: Parser<x, c>) -> Parser<[a], c> {
   return p >>- { x in
     sep >>> sepEndBy(p, sep) >>- { xs in
       var r = [x]
@@ -134,7 +134,7 @@ public func sepEndBy1<a, c: Collection, x> (_ p: Parser<a, c>.T, _ sep: Parser<x
     separated and optionally ended by `sep`. Returns a list
     of values returned by `p`.
 */
-public func sepEndBy<a, c: Collection, x> (_ p: Parser<a, c>.T, _ sep: Parser<x, c>.T) -> Parser<[a], c>.T {
+public func sepEndBy<a, c: Collection, x> (_ p: Parser<a, c>, _ sep: Parser<x, c>) -> Parser<[a], c> {
   return sepEndBy1(p, sep) <|> create([])
 }
 
@@ -142,7 +142,7 @@ public func sepEndBy<a, c: Collection, x> (_ p: Parser<a, c>.T, _ sep: Parser<x,
     `endBy1(p, sep)` parses *one* or more occurrences of `p`, separated
     and ended by `sep`. Returns a list of values returned by `p`.
 */
-public func endBy1<a, c: Collection, x> (_ p: Parser<a, c>.T, _ sep: Parser<x, c>.T) -> Parser<[a], c>.T {
+public func endBy1<a, c: Collection, x> (_ p: Parser<a, c>, _ sep: Parser<x, c>) -> Parser<[a], c> {
   return many1(p >>- { x in sep >>> create(x) })
 }
 
@@ -150,7 +150,7 @@ public func endBy1<a, c: Collection, x> (_ p: Parser<a, c>.T, _ sep: Parser<x, c
     `endBy(p, sep)` parses *zero* or more occurrences of `p`, separated
     and ended by `sep`. Returns a list of values returned by `p`.
 */
-public func endBy<a, c: Collection, x> (_ p: Parser<a, c>.T, _ sep: Parser<x, c>.T) -> Parser<[a], c>.T {
+public func endBy<a, c: Collection, x> (_ p: Parser<a, c>, _ sep: Parser<x, c>) -> Parser<[a], c> {
   return many(p >>- { x in sep >>> create(x) })
 }
 
@@ -159,7 +159,7 @@ public func endBy<a, c: Collection, x> (_ p: Parser<a, c>.T, _ sep: Parser<x, c>
     equal to zero, the parser equals to `create([])`. Returns a list of
     `n` values returned by `p`.
 */
-public func count<a, c: Collection> (_ n: Int, _ p: Parser<a, c>.T) -> Parser<[a], c>.T {
+public func count<a, c: Collection> (_ n: Int, _ p: Parser<a, c>) -> Parser<[a], c> {
   if n <= 0 {
     return create([])
   } else {
@@ -167,7 +167,7 @@ public func count<a, c: Collection> (_ n: Int, _ p: Parser<a, c>.T) -> Parser<[a
   }
 }
 
-func sequence<a, c: Collection> (_ ps: ArraySlice<Parser<a, c>.T>) -> Parser<[a], c>.T {
+func sequence<a, c: Collection> (_ ps: ArraySlice<Parser<a, c>>) -> Parser<[a], c> {
   if let p = ps.first {
     return p >>- { x in
       sequence(ps.dropFirst()) >>- { xs in
@@ -188,7 +188,7 @@ func sequence<a, c: Collection> (_ ps: ArraySlice<Parser<a, c>.T>) -> Parser<[a]
     by `p`. If there are no occurrences of `p`, the value `x` is
     returned.
 */
-public func chainr<a, c: Collection> (_ p: Parser<a, c>.T, _ op: Parser<(a, a) -> a, c>.T, _ x: a) -> Parser<a, c>.T {
+public func chainr<a, c: Collection> (_ p: Parser<a, c>, _ op: Parser<(a, a) -> a, c>, _ x: a) -> Parser<a, c> {
   return chainr1(p, op) <|> create(x)
 }
 
@@ -199,7 +199,7 @@ public func chainr<a, c: Collection> (_ p: Parser<a, c>.T, _ op: Parser<(a, a) -
     by `p`. If there are no occurrences of `p`, the value `x` is
     returned.
 */
-public func chainl<a, c: Collection> (_ p: Parser<a, c>.T, _ op: Parser<(a, a) -> a, c>.T, _ x: a) -> Parser<a, c>.T {
+public func chainl<a, c: Collection> (_ p: Parser<a, c>, _ op: Parser<(a, a) -> a, c>, _ x: a) -> Parser<a, c> {
   return chainl1(p, op) <|> create(x)
 }
 
@@ -210,27 +210,27 @@ public func chainl<a, c: Collection> (_ p: Parser<a, c>.T, _ op: Parser<(a, a) -
     by `p`. This parser can for example be used to eliminate left
     recursion which typically occurs in expression grammars.
 
-        func expr () -> StringParser<Int>.T {
+        func expr () -> StringParser<Int> {
           return chainl1(term(), addop())
         }
-        func term () -> StringParser<Int>.T {
+        func term () -> StringParser<Int> {
           return chainl1(factor(), mulop())
         }
-        func factor () -> StringParser<Int>.T {
+        func factor () -> StringParser<Int> {
           return parens(expr()) <|> integer()
         }
 
-        func mulop () -> StringParser<(Int, Int) -> Int>.T {
+        func mulop () -> StringParser<(Int, Int) -> Int> {
           return char("*") >>> create(*)
               <|> char("/") >>> create(/)
         }
-        func addop () -> StringParser<(Int, Int) -> Int>.T {
+        func addop () -> StringParser<(Int, Int) -> Int> {
           return char("+") >>> create(+)
               <|> char("-") >>> create(-)
         }
 */
-public func chainl1<a, c: Collection> (_ p: Parser<a, c>.T, _ op: Parser<(a, a) -> a, c>.T) -> Parser<a, c>.T {
-  func rest (_ x: a) -> Parser<a, c>.T {
+public func chainl1<a, c: Collection> (_ p: Parser<a, c>, _ op: Parser<(a, a) -> a, c>) -> Parser<a, c> {
+  func rest (_ x: a) -> Parser<a, c> {
     return op >>- { f in
       p >>- { y in
         rest(f(x, y))
@@ -246,11 +246,11 @@ public func chainl1<a, c: Collection> (_ p: Parser<a, c>.T, _ op: Parser<(a, a) 
     application of all functions returned by `op` to the values returned
     by `p`.
 */
-public func chainr1<a, c: Collection> (_ p: Parser<a, c>.T, _ op: Parser<(a, a) -> a, c>.T) -> Parser<a, c>.T {
-  func scan () -> Parser<a, c>.T {
+public func chainr1<a, c: Collection> (_ p: Parser<a, c>, _ op: Parser<(a, a) -> a, c>) -> Parser<a, c> {
+  func scan () -> Parser<a, c> {
     return p >>- { x in rest(x) }
   }
-  func rest (_ x: a) -> Parser<a, c>.T {
+  func rest (_ x: a) -> Parser<a, c> {
     return op >>- { f in
       scan() >>- { y in
         create(f(x, y))
@@ -268,7 +268,7 @@ public func chainr1<a, c: Collection> (_ p: Parser<a, c>.T, _ op: Parser<(a, a) 
     The parser `anyToken` accepts any kind of token. It is for example
     used to implement 'eof'. Returns the accepted token.
 */
-public func anyToken<c: Collection> () -> Parser<c.Iterator.Element, c>.T
+public func anyToken<c: Collection> () -> Parser<c.Iterator.Element, c>
   where c.SubSequence == c
 {
   return tokenPrim({ String(describing: $0) }, { pos, _, _ in pos }, { $0 })
@@ -278,7 +278,7 @@ public func anyToken<c: Collection> () -> Parser<c.Iterator.Element, c>.T
     This parser only succeeds at the end of the input. This is not a
     primitive parser but it is defined using 'notFollowedBy'.
 */
-public func eof<c: Collection> () -> Parser<(), c>.T
+public func eof<c: Collection> () -> Parser<(), c>
   where c.SubSequence == c
 {
   return notFollowedBy(anyToken()) <?> "end of input"
@@ -293,11 +293,11 @@ public func eof<c: Collection> () -> Parser<(), c>.T
     actually an identifier (for example `lets`). We can program this
     behaviour as follows:
 
-        func keywordLet () -> StringParser<String>.T {
+        func keywordLet () -> StringParser<String> {
           return attempt(string("let") <<< notFollowedBy(alphaNum()))
         }
 */
-public func notFollowedBy<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<(), c>.T {
+public func notFollowedBy<a, c: Collection> (_ p: Parser<a, c>) -> Parser<(), c> {
   return attempt(
     attempt(p) >>- { c in unexpected(String(describing: c))}
     <|> create(())
@@ -309,15 +309,15 @@ public func notFollowedBy<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<(), 
     parser `end` succeeds. Returns the list of values returned by `p`.
     This parser can be used to scan comments:
 
-        func simpleComment () -> StringParser<String>.T {
+        func simpleComment () -> StringParser<String> {
           return string("<!--") >>> manyTill(anyChar(), attempt(string("-->"))) >>- { cs in create(String(cs)) }
         }
 
     Note the overlapping parsers `anyChar` and `string("-->")`, and
     therefore the use of the 'attempt' combinator.
 */
-public func manyTill<a, c: Collection, x> (_ p: Parser<a, c>.T, _ end: Parser<x, c>.T) -> Parser<[a], c>.T {
-  func scan () -> Parser<[a], c>.T {
+public func manyTill<a, c: Collection, x> (_ p: Parser<a, c>, _ end: Parser<x, c>) -> Parser<[a], c> {
+  func scan () -> Parser<[a], c> {
     return end >>> create([])
         <|> p >>- { x in
           scan() >>- { xs in

--- a/Parsec/Primitive.swift
+++ b/Parsec/Primitive.swift
@@ -2,11 +2,7 @@
     The primitive parser combinators.
 */
 
-// public typealias Parser<a, c: Collection> = (State<c>) -> Consumed<a, c>
-// https://www.packtpub.com/books/content/how-make-generic-typealiases-swift
-public enum Parser<a, c: Collection> {
-  public typealias T = (State<c>) -> Consumed<a, c>
-}
+public typealias Parser<a, c: Collection> = (State<c>) -> Consumed<a, c>
 
 public enum Consumed<a, c: Collection> {
   case consumed(Lazy<Reply<a, c>>)
@@ -69,7 +65,7 @@ public enum Either<l, r> {
   case right(r)
 }
 
-public func create<a, c: Collection> (_ x: a) -> Parser<a, c>.T {
+public func create<a, c: Collection> (_ x: a) -> Parser<a, c> {
   return parserReturn(x)
 }
 
@@ -87,17 +83,17 @@ precedencegroup LabelPrecedence {
 }
 
 infix operator >>- : BindPrecedence
-public func >>- <a, b, c: Collection> (p: Parser<a, c>.T, f: @escaping (a) -> Parser<b, c>.T) -> Parser<b, c>.T {
+public func >>- <a, b, c: Collection> (p: Parser<a, c>, f: @escaping (a) -> Parser<b, c>) -> Parser<b, c> {
   return parserBind(p, f)
 }
 
 infix operator >>> : BindPrecedence
-public func >>> <a, b, c: Collection> (p: Parser<a, c>.T, q: Parser<b, c>.T) -> Parser<b, c>.T {
+public func >>> <a, b, c: Collection> (p: Parser<a, c>, q: Parser<b, c>) -> Parser<b, c> {
   return p >>- { _ in q }
 }
 
 infix operator <<< : BindPrecedence
-public func <<< <a, b, c: Collection> (p: Parser<a, c>.T, q: Parser<b, c>.T) -> Parser<a, c>.T {
+public func <<< <a, b, c: Collection> (p: Parser<a, c>, q: Parser<b, c>) -> Parser<a, c> {
   return p >>- { x in q >>> create(x) }
 }
 
@@ -110,21 +106,21 @@ public func <<< <a, b, c: Collection> (p: Parser<a, c>.T, q: Parser<b, c>.T) -> 
     used. For an example of the use of `unexpected`, see the definition
     of `notFollowedBy`.
 */
-public func unexpected<a, c: Collection> (_ msg: String) -> Parser<a, c>.T {
+public func unexpected<a, c: Collection> (_ msg: String) -> Parser<a, c> {
   return { state in
     .empty(.error(ParseError(state.pos, [.unExpect(msg)])))
   }
 }
 
-public func fail<a, c: Collection> (_ msg: String) -> Parser<a, c>.T {
+public func fail<a, c: Collection> (_ msg: String) -> Parser<a, c> {
   return parserFail(msg)
 }
 
-public func parserReturn<a, c: Collection> (_ x: a) -> Parser<a, c>.T {
+public func parserReturn<a, c: Collection> (_ x: a) -> Parser<a, c> {
   return { state in .empty(.ok(x, state, unknownError(state))) }
 }
 
-public func parserBind<a, b, c: Collection> (_ p: Parser<a, c>.T, _ f: @escaping (a) -> Parser<b, c>.T) -> Parser<b, c>.T {
+public func parserBind<a, b, c: Collection> (_ p: Parser<a, c>, _ f: @escaping (a) -> Parser<b, c>) -> Parser<b, c> {
   return { state in
     switch p(state) {
 
@@ -159,7 +155,7 @@ public func parserBind<a, b, c: Collection> (_ p: Parser<a, c>.T, _ f: @escaping
   }
 }
 
-public func parserFail<a, c: Collection> (_ msg: String) -> Parser<a, c>.T {
+public func parserFail<a, c: Collection> (_ msg: String) -> Parser<a, c> {
   return { state in
     .empty(.error(ParseError(state.pos, .message(msg))))
   }
@@ -168,13 +164,13 @@ public func parserFail<a, c: Collection> (_ msg: String) -> Parser<a, c>.T {
 /**
     `parserZero` always fails without consuming any input.
 */
-public func parserZero<a, c: Collection> () -> Parser<a, c>.T {
+public func parserZero<a, c: Collection> () -> Parser<a, c> {
   return { state in
     .empty(.error(unknownError(state)))
   }
 }
 
-public func parserPlus<a, c: Collection> (_ p: Parser<a, c>.T, _ q: Parser<a, c>.T) -> Parser<a, c>.T {
+public func parserPlus<a, c: Collection> (_ p: Parser<a, c>, _ q: Parser<a, c>) -> Parser<a, c> {
   return { state in
     switch p(state) {
     case let .empty(.error(msg1)):
@@ -204,15 +200,15 @@ public func parserPlus<a, c: Collection> (_ p: Parser<a, c>.T, _ q: Parser<a, c>
     rather than returning all possible characters.
 */
 infix operator <?> : LabelPrecedence
-public func <?> <a, c: Collection> (p: Parser<a, c>.T, msg: String) -> Parser<a, c>.T {
+public func <?> <a, c: Collection> (p: Parser<a, c>, msg: String) -> Parser<a, c> {
   return label(p, msg)
 }
 
-public func label<a, c: Collection> (_ p: Parser<a, c>.T, _ msg: String) -> Parser<a, c>.T {
+public func label<a, c: Collection> (_ p: Parser<a, c>, _ msg: String) -> Parser<a, c> {
   return labels(p, [msg])
 }
 
-public func labels<a, c: Collection> (_ p: Parser<a, c>.T, _ msgs: [String]) -> Parser<a, c>.T {
+public func labels<a, c: Collection> (_ p: Parser<a, c>, _ msgs: [String]) -> Parser<a, c> {
   return { state in
     switch p(state) {
     case let .empty(.error(err)): return .empty(.error(setExpectErrors(err, msgs)))
@@ -246,7 +242,7 @@ func setExpectErrors (_ err: ParseError, _ msgs: [String]) -> ParseError {
     error messages.
 */
 infix operator <|> : ChoicePrecedence
-public func <|> <a, c:Collection> (p: Parser<a, c>.T, q: Parser<a, c>.T) -> Parser<a, c>.T {
+public func <|> <a, c:Collection> (p: Parser<a, c>, q: Parser<a, c>) -> Parser<a, c> {
   return parserPlus(p, q)
 }
 
@@ -267,10 +263,10 @@ public func <|> <a, c:Collection> (p: Parser<a, c>.T, q: Parser<a, c>.T) -> Pars
 
         expr        = letExpr() <|> identifier() <?> "expression"
 
-        func letExpr<a, c: Collection> () -> Parser<a, c>.T {
+        func letExpr<a, c: Collection> () -> Parser<a, c> {
           return string("let") ...
         }
-        func identifier<a, c: Collection> () -> Parser<a, c>.T {
+        func identifier<a, c: Collection> () -> Parser<a, c> {
           return many1(letter())
         }
 
@@ -283,14 +279,14 @@ public func <|> <a, c:Collection> (p: Parser<a, c>.T, q: Parser<a, c>.T) -> Pars
 
         expr        = letExpr() <|> identifier() <?> "expression"
 
-        func letExpr<a, c: Collection> () -> Parser<a, c>.T {
+        func letExpr<a, c: Collection> () -> Parser<a, c> {
           return attempt(string("let")) ...
         }
-        func identifier<a, c: Collection> () -> Parser<a, c>.T {
+        func identifier<a, c: Collection> () -> Parser<a, c> {
           return many1(letter())
         }
 */
-public func attempt<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<a, c>.T {
+public func attempt<a, c: Collection> (_ p: Parser<a, c>) -> Parser<a, c> {
   return { state in
     switch p(state) {
     case let .consumed(reply):
@@ -309,7 +305,7 @@ public func attempt<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<a, c>.T {
     If `p` fails and consumes some input, so does `lookAhead`. Combine with
     `attempt` if this is undesirable.
 */
-public func lookAhead<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<a, c>.T {
+public func lookAhead<a, c: Collection> (_ p: Parser<a, c>) -> Parser<a, c> {
   return { state in
     switch p(state) {
     case let .consumed(reply):
@@ -333,14 +329,14 @@ public func lookAhead<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<a, c>.T 
     suppose that we have a stream of basic tokens tupled with source
     positions. We can then define a parser that accepts single tokens as:
 
-        func myToken<a, c: Collection> (_ x: c.Iterator.Element) -> Parser<a, c>.T {
+        func myToken<a, c: Collection> (_ x: c.Iterator.Element) -> Parser<a, c> {
           let showToken = { (pos, t) in String(t) }
           let posFromTok = { (pos, t) in pos }
           let testTok = { (pos, t) in if x == t { return t } else { return nil } }
           return token(showTok, posFromTok, testTok)
         }
 */
-public func token<a, c: Collection> (_ showToken: @escaping (c.Iterator.Element) -> String, _ tokenPosition: @escaping (c.Iterator.Element) -> SourcePos, _ test: @escaping (c.Iterator.Element) -> a?) -> Parser<a, c>.T
+public func token<a, c: Collection> (_ showToken: @escaping (c.Iterator.Element) -> String, _ tokenPosition: @escaping (c.Iterator.Element) -> SourcePos, _ test: @escaping (c.Iterator.Element) -> a?) -> Parser<a, c>
   where c.SubSequence == c
 {
   let nextPosition: (SourcePos, c.Iterator.Element, c) -> SourcePos = { _, current, rest in
@@ -353,7 +349,7 @@ public func token<a, c: Collection> (_ showToken: @escaping (c.Iterator.Element)
   return tokenPrim(showToken, nextPosition, test)
 }
 
-public func tokens<c: Collection> (_ showTokens: @escaping ([c.Iterator.Element]) -> String, _ nextPosition: @escaping (SourcePos, [c.Iterator.Element]) -> SourcePos, _ tts: [c.Iterator.Element]) -> Parser<[c.Iterator.Element], c>.T
+public func tokens<c: Collection> (_ showTokens: @escaping ([c.Iterator.Element]) -> String, _ nextPosition: @escaping (SourcePos, [c.Iterator.Element]) -> SourcePos, _ tts: [c.Iterator.Element]) -> Parser<[c.Iterator.Element], c>
   where c.Iterator.Element: Equatable, c.SubSequence == c
 {
   if let tok = tts.first {
@@ -402,7 +398,7 @@ public func tokens<c: Collection> (_ showTokens: @escaping ([c.Iterator.Element]
     This is the most primitive combinator for accepting tokens. For
     example, the `char` parser could be implemented as:
 
-        func char<Character, c: Collection> (c: Character) -> Parser<Character, c>.T
+        func char<Character, c: Collection> (c: Character) -> Parser<Character, c>
           where c.Iterator.Element == Character
         {
           let showChar = { x: Character in "\"\(x)\"" }
@@ -411,7 +407,7 @@ public func tokens<c: Collection> (_ showTokens: @escaping ([c.Iterator.Element]
           return tokenPrim(showChar, nextPos, testChar)
         }
 */
-public func tokenPrim<a, c: Collection> (_ showToken: @escaping (c.Iterator.Element) -> String, _ nextPosition: @escaping (SourcePos, c.Iterator.Element, c) -> SourcePos, _ test: @escaping (c.Iterator.Element) -> a?) -> Parser<a, c>.T
+public func tokenPrim<a, c: Collection> (_ showToken: @escaping (c.Iterator.Element) -> String, _ nextPosition: @escaping (SourcePos, c.Iterator.Element, c) -> SourcePos, _ test: @escaping (c.Iterator.Element) -> a?) -> Parser<a, c>
   where c.SubSequence == c
 {
   return { state in
@@ -432,7 +428,7 @@ public func tokenPrim<a, c: Collection> (_ showToken: @escaping (c.Iterator.Elem
     `many(p)` applies the parser `p` *zero* or more times. Returns a
     list of the returned values of `p`.
 
-        func identifier<a, c: Collection> () -> Parser<[a], c>.T {
+        func identifier<a, c: Collection> () -> Parser<[a], c> {
           return letter() >>- { c in
             many(alphaNum() <|> char("_")) >>- { cs in
               var r = cs
@@ -442,7 +438,7 @@ public func tokenPrim<a, c: Collection> (_ showToken: @escaping (c.Iterator.Elem
           }
         }
 */
-public func many<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<[a], c>.T {
+public func many<a, c: Collection> (_ p: Parser<a, c>) -> Parser<[a], c> {
   return manyAccum(append, p)
 }
 
@@ -456,15 +452,15 @@ func append<a> (_ next: a, _ list: [a]) -> [a] {
     `skipMany(p)` applies the parser `p` *zero* or more times, skipping
     its result.
 
-        func spaces<c: Collection> () -> Parser<(), c>.T {
+        func spaces<c: Collection> () -> Parser<(), c> {
           return skipMany(space())
         }
 */
-public func skipMany<a, c: Collection> (_ p: Parser<a, c>.T) -> Parser<(), c>.T {
+public func skipMany<a, c: Collection> (_ p: Parser<a, c>) -> Parser<(), c> {
   return manyAccum({ _, _ in [] }, p) >>> create(())
 }
 
-public func manyAccum<a, c: Collection> (_ acc: @escaping (a, [a]) -> [a], _ p: Parser<a, c>.T) -> Parser<[a], c>.T {
+public func manyAccum<a, c: Collection> (_ acc: @escaping (a, [a]) -> [a], _ p: Parser<a, c>) -> Parser<[a], c> {
   let msg = "Parsec many: combinator 'many' is applied to a parser that accepts an empty string."
   func walk (_ xs: [a], _ x: a, _ state: State<c>, _ err: ParseError) -> Consumed<[a], c> {
     switch p(state) {
@@ -496,7 +492,7 @@ public func manyAccum<a, c: Collection> (_ acc: @escaping (a, [a]) -> [a], _ p: 
   }
 }
 
-public func runP<a, c: Collection> (_ p: Parser<a, c>.T, _ name: String, _ input: c) -> Either<ParseError, a> {
+public func runP<a, c: Collection> (_ p: Parser<a, c>, _ name: String, _ input: c) -> Either<ParseError, a> {
   switch p(State(input, SourcePos(name))) {
   case let .consumed(reply):
     switch reply.value {
@@ -519,12 +515,12 @@ public func runP<a, c: Collection> (_ p: Parser<a, c>.T, _ name: String, _ input
     string. Returns either a 'ParseError' ('left') or a
     value of type `a` ('right').
 
-        func parseFromFile<a, c: Collection> (_ p: Parser<a, c>.T, _ fileUrl: String) -> Either<ParseError, a> {
+        func parseFromFile<a, c: Collection> (_ p: Parser<a, c>, _ fileUrl: String) -> Either<ParseError, a> {
           let input = String(contentsOf: fileUrl)
           return runParser(p, fileUrl, input)
         }
 */
-public func runParser<a, c: Collection> (_ p: Parser<a, c>.T, _ name: String, _ input: c) -> Either<ParseError, a> {
+public func runParser<a, c: Collection> (_ p: Parser<a, c>, _ name: String, _ input: c) -> Either<ParseError, a> {
   return runP(p, name, input)
 }
 
@@ -541,15 +537,15 @@ public func runParser<a, c: Collection> (_ p: Parser<a, c>.T, _ name: String, _ 
           }
         }
 
-        func numbers<c: Collection> () -> Parser<[Int], c>.T {
+        func numbers<c: Collection> () -> Parser<[Int], c> {
           return commaSep(integer())
         }
 */
-public func parse<a, c: Collection> (_ p: Parser<a, c>.T, _ name: String, _ input: c) -> Either<ParseError, a> {
+public func parse<a, c: Collection> (_ p: Parser<a, c>, _ name: String, _ input: c) -> Either<ParseError, a> {
   return runP(p, name, input)
 }
 
-public func parseTest<a, c: Collection> (_ p: Parser<a, c>.T, _ input: c) {
+public func parseTest<a, c: Collection> (_ p: Parser<a, c>, _ input: c) {
   switch parse(p, "", input) {
   case let .left(err): print(err)
   case let .right(x): print(x)
@@ -559,7 +555,7 @@ public func parseTest<a, c: Collection> (_ p: Parser<a, c>.T, _ input: c) {
 /**
     Returns the current source position. See also 'SourcePos'.
 */
-public func getPosition<c: Collection> () -> Parser<SourcePos, c>.T {
+public func getPosition<c: Collection> () -> Parser<SourcePos, c> {
   return getParserState() >>- { state in
     create(state.pos)
   }
@@ -568,7 +564,7 @@ public func getPosition<c: Collection> () -> Parser<SourcePos, c>.T {
 /**
     Returns the current input.
 */
-public func getInput<c: Collection> () -> Parser<c, c>.T {
+public func getInput<c: Collection> () -> Parser<c, c> {
   return getParserState() >>- { state in
     create(state.input)
   }
@@ -577,7 +573,7 @@ public func getInput<c: Collection> () -> Parser<c, c>.T {
 /**
     `setPosition(pos)` sets the current source position to `pos`.
 */
-public func setPosition<c: Collection> (_ pos: SourcePos) -> Parser<(), c>.T {
+public func setPosition<c: Collection> (_ pos: SourcePos) -> Parser<(), c> {
   return updateParserState { state in State(state.input, pos) } >>> create(())
 }
 
@@ -586,28 +582,28 @@ public func setPosition<c: Collection> (_ pos: SourcePos) -> Parser<(), c>.T {
     `setInput` functions can for example be used to deal with #include
     files.
 */
-public func setInput<c: Collection> (_ input: c) -> Parser<(), c>.T {
+public func setInput<c: Collection> (_ input: c) -> Parser<(), c> {
   return updateParserState { state in State(input, state.pos) } >>> create(())
 }
 
 /**
     Returns the full parser state as a 'State' record.
 */
-public func getParserState<c: Collection> () -> Parser<State<c>, c>.T {
+public func getParserState<c: Collection> () -> Parser<State<c>, c> {
   return updateParserState { state in state }
 }
 
 /**
     `setParserState(state)` set the full parser state to `state`.
 */
-public func setParserState<c: Collection> (_ state: State<c>) -> Parser<State<c>, c>.T {
+public func setParserState<c: Collection> (_ state: State<c>) -> Parser<State<c>, c> {
   return updateParserState { _ in state }
 }
 
 /**
     `updateParserState(f)` applies function `f` to the parser state.
 */
-public func updateParserState<c: Collection> (_ f: @escaping (State<c>) -> State<c>) -> Parser<State<c>, c>.T {
+public func updateParserState<c: Collection> (_ f: @escaping (State<c>) -> State<c>) -> Parser<State<c>, c> {
   return { state in
     let newState = f(state)
     return .empty(.ok(newState, newState, unknownError(newState)))

--- a/Parsec/String.swift
+++ b/Parsec/String.swift
@@ -1,9 +1,7 @@
 /**
     `StringParser<a>` is an alias for `Parser<a, String.CharacterView>`.
 */
-public enum StringParser<a> {
-  public typealias T = Parser<a, String.CharacterView>.T
-}
+public typealias StringParser<a> = (State<String.CharacterView>) -> Consumed<a, String.CharacterView>
 
 /**
     `parse(p, file: filePath)` runs a string parser `p` on the
@@ -18,7 +16,7 @@ public enum StringParser<a> {
       }
     }
 */
-public func parse<a, c: Collection> (_ p: Parser<a, c>.T, contentsOfFile file: String) throws -> Either<ParseError, a> {
+public func parse<a, c: Collection> (_ p: Parser<a, c>, contentsOfFile file: String) throws -> Either<ParseError, a> {
   let contents = try String(contentsOfFile: file)
   return parse(p, file, contents.characters as! c)
 }

--- a/example-csv-advanced/main.swift
+++ b/example-csv-advanced/main.swift
@@ -1,34 +1,34 @@
 import Parsec
 
-func csv () -> StringParser<[[String]]>.T {
+func csv () -> StringParser<[[String]]> {
   return endBy(line(), endOfLine())
 }
 
-func line () -> StringParser<[String]>.T {
+func line () -> StringParser<[String]> {
   return sepBy(cell(), char(","))
 }
 
-func cell () -> StringParser<String>.T {
+func cell () -> StringParser<String> {
   return quotedCell() <|> simpleCell()
 }
 
-func simpleCell () -> StringParser<String>.T {
+func simpleCell () -> StringParser<String> {
   return many(noneOf(",\n")) >>- { cs in create(String(cs)) }
 }
 
-func quotedCell () -> StringParser<String>.T {
+func quotedCell () -> StringParser<String> {
   return between(char("\""), char("\""), quotedCellContent())
 }
 
-func quotedCellContent () -> StringParser<String>.T {
+func quotedCellContent () -> StringParser<String> {
   return many(quotedCellChar()) >>- { cs in create(String(cs)) }
 }
 
-func quotedCellChar () -> StringParser<Character>.T {
+func quotedCellChar () -> StringParser<Character> {
   return noneOf("\"") <|> escapedQuote()
 }
 
-func escapedQuote () -> StringParser<Character>.T {
+func escapedQuote () -> StringParser<Character> {
   return attempt(string("\"\"") <?> "escaped double quote") >>> create("\"")
 }
 

--- a/example-csv-simple/main.swift
+++ b/example-csv-simple/main.swift
@@ -1,14 +1,14 @@
 import Parsec
 
-func csv () -> StringParser<[[String]]>.T {
+func csv () -> StringParser<[[String]]> {
   return endBy(line(), char("\n"))
 }
 
-func line () -> StringParser<[String]>.T {
+func line () -> StringParser<[String]> {
   return sepBy(cell(), char(","))
 }
 
-func cell () -> StringParser<String>.T {
+func cell () -> StringParser<String> {
   return many(noneOf(",\n")) >>- { chars in create(String(chars)) }
 }
 

--- a/example-json/main.swift
+++ b/example-json/main.swift
@@ -9,11 +9,11 @@ enum Json {
   case object([String: Json])
 }
 
-func jsonFile () -> StringParser<Json>.T {
+func jsonFile () -> StringParser<Json> {
   return spaces() >>> value() <<< eof()
 }
 
-func value () -> StringParser<Json>.T {
+func value () -> StringParser<Json> {
   return str()
       <|> number()
       <|> object()
@@ -23,20 +23,20 @@ func value () -> StringParser<Json>.T {
       <?> "json value"
 }
 
-func str () -> StringParser<Json>.T {
+func str () -> StringParser<Json> {
   return quotedString() >>- { s in create(.string(s)) }
 }
 
-func quotedString () -> StringParser<String>.T {
+func quotedString () -> StringParser<String> {
   return between(quote(), quote(), many(quotedCharacter()))
         >>- { cs in create(String(cs)) } <<< spaces() <?> "quoted string"
 }
 
-func quote () -> StringParser<Character>.T {
+func quote () -> StringParser<Character> {
   return char("\"") <?> "double quote"
 }
 
-func quotedCharacter () -> StringParser<Character>.T {
+func quotedCharacter () -> StringParser<Character> {
   var chars = "\"\\"
   for i in 0x00...0x1f {
     chars += String(describing: UnicodeScalar(i)!)
@@ -60,7 +60,7 @@ func quotedCharacter () -> StringParser<Character>.T {
           })
 }
 
-func number () -> StringParser<Json>.T {
+func number () -> StringParser<Json> {
   return numberSign() >>- { sign in
     numberFixed() >>- { fixed in
       numberFraction() >>- { fraction in
@@ -77,27 +77,27 @@ func number () -> StringParser<Json>.T {
   } <<< spaces() <?> "number"
 }
 
-func numberSign () -> StringParser<String>.T {
+func numberSign () -> StringParser<String> {
   return option("+", string("-"))
 }
 
-func numberFixed () -> StringParser<String>.T {
+func numberFixed () -> StringParser<String> {
   return string("0") <|> many1(digit()) >>- { create(String($0)) }
 }
 
-func numberFraction () -> StringParser<String>.T {
+func numberFraction () -> StringParser<String> {
   return char(".") >>> many1(digit()) >>- { create("." + String($0)) }
     <|> create("")
 }
 
-func numberExponent () -> StringParser<String>.T {
+func numberExponent () -> StringParser<String> {
   return oneOf("eE") >>> option("+", oneOf("+-")) >>- { sign in
       many1(digit()) >>- { digits in create("e" + String(sign) + String(digits)) }
     }
     <|> create("")
 }
 
-func object () -> StringParser<Json>.T {
+func object () -> StringParser<Json> {
   return between(leftBrace(), rightBrace(), sepBy(pair(), comma())) >>- { ps in
     var r: [String: Json] = [:]
     ps.forEach { p in r[p.0] = p.1 }
@@ -105,23 +105,23 @@ func object () -> StringParser<Json>.T {
   } <?> "object"
 }
 
-func leftBrace () -> StringParser<Character>.T {
+func leftBrace () -> StringParser<Character> {
   return char("{") <<< spaces() <?> "open curly bracket"
 }
 
-func rightBrace () -> StringParser<Character>.T {
+func rightBrace () -> StringParser<Character> {
   return char("}") <<< spaces() <?> "close curly bracket"
 }
 
-func comma () -> StringParser<Character>.T {
+func comma () -> StringParser<Character> {
   return char(",") <<< spaces() <?> "comma"
 }
 
-func colon () -> StringParser<Character>.T {
+func colon () -> StringParser<Character> {
   return char(":") <<< spaces() <?> "colon"
 }
 
-func pair () -> StringParser<(String, Json)>.T {
+func pair () -> StringParser<(String, Json)> {
   return quotedString() >>- { k in
     colon() >>> value() >>- { v in
       create((k, v))
@@ -129,12 +129,12 @@ func pair () -> StringParser<(String, Json)>.T {
   } <?> "key:value pair"
 }
 
-func array () -> StringParser<Json>.T {
+func array () -> StringParser<Json> {
   // the next line crashes the compiler with "Segmentation fault: 11"
   // return between(leftBracket(), rightBracket(), sepBy(value(), comma()))
   //     >>- { js in create(.array(js)) }
   // as a result, we can't have an array within an array for now
-  func element () -> StringParser<Json>.T {
+  func element () -> StringParser<Json> {
     return null() <|> bool() <|> number() <|> str() <|> object()
   }
   return between(leftBracket(), rightBracket(), sepBy(element(), comma()))
@@ -142,20 +142,20 @@ func array () -> StringParser<Json>.T {
       <?> "array"
 }
 
-func leftBracket () -> StringParser<Character>.T {
+func leftBracket () -> StringParser<Character> {
   return char("[") <<< spaces() <?> "open square bracket"
 }
 
-func rightBracket () -> StringParser<Character>.T {
+func rightBracket () -> StringParser<Character> {
   return char("]") <<< spaces() <?> "close square bracket"
 }
 
-func bool () -> StringParser<Json>.T {
+func bool () -> StringParser<Json> {
   return (string("true") >>> create(.bool(true)) <<< spaces() <?> "true")
       <|> (string("false") >>> create(.bool(false)) <<< spaces() <?> "false")
 }
 
-func null () -> StringParser<Json>.T {
+func null () -> StringParser<Json> {
   return string("null") >>> create(.null) <<< spaces() <?> "null"
 }
 


### PR DESCRIPTION
The workaround linked to at https://www.packtpub.com/books/content/how-make-generic-typealiases-swift is no longer necessary. Unfortunately, setting `typealias StringParser<a> = Parser<a, String.CharacterView>` segfaults the compiler, so it uses the expanded form.
